### PR TITLE
Zeke's Design Ideas

### DIFF
--- a/src/404.md
+++ b/src/404.md
@@ -4,6 +4,8 @@ title:  "Sorry, Not Found"
 permalink: "404.html"
 ---
 
+<section class="main">
+<div class="section-content">
 
 <div class="landing-image">
     <svg xmlns="http://www.w3.org/2000/svg"  
@@ -15,3 +17,5 @@ permalink: "404.html"
 
 Sorry, we couln't find the droids you were looking for.
 
+</div>
+</section>

--- a/src/_includes/default-layout.njk
+++ b/src/_includes/default-layout.njk
@@ -39,10 +39,10 @@
             <img class="logo" src="/assets/vermont-code-camp-logo-light.svg" alt="logo" />
         </a>
         <ul class="nav-buttons">
+            <li><a href="/" class='code {{ "active" if homepage }}'>Attend<span class="hide-xs">();</span></a></li>
             <li><a href="/speak" class='code {{ "active" if "/speak/" in page.url }}'>Speak<span class="hide-xs">();</span></a></li>
             <li><a href="/sponsor" class='code {{ "active" if "/sponsor/" in page.url }}'>Sponsor<span class="hide-xs">();</span></a></li>
-            <li><a href="https://www.vtcodecamp.org/" class="code" ><span class="hide-xs">Get</span>History<span class="hide-xs">();</span></a></li>
-        </ul>
+           
     </header>
 
     <main class="content">

--- a/src/_includes/default-layout.njk
+++ b/src/_includes/default-layout.njk
@@ -46,19 +46,10 @@
     </header>
 
     <main class="content">
-        <div class="main" >
-            <h1>{{title}}</h1>
-
-            {{ content | safe }}
-        </div>
-        <aside class="twitter">
-            <a class="twitter-timeline" href="https://twitter.com/VTCodeCamp?ref_src=twsrc%5Etfw"
-               data-dnt="true" data-link-color="#2B7BB9">Tweets by @VTCodeCamp</a> 
-            <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-        </aside>
+        
+        {{ content | safe }}
+    
     </main>
-
-
 
 
     <footer class="footer">

--- a/src/_includes/embedded-tweets.html
+++ b/src/_includes/embedded-tweets.html
@@ -1,0 +1,38 @@
+
+<div id="tweet-container" class="embedded-tweets"></div>
+
+<script src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+<script>
+    let tweets = [
+        '1101986121041498113', //VTCodeCamp
+        '1041026386377486336', //MalinaKirn
+        '1057626199239868416', //bhoblin
+        '1101265245056716800', //VTCodeCamp
+        '1053587150757945344', //VTCodeCamp
+        
+        '1041030382228004865', //davekopec
+        '1045101432234487808', //VTCodeCamp
+        '1041336710192418817', //FlorenceFong8
+        '1041146235229560832', //tchen
+        '1042379420974178305', //VTCodeCamp
+        
+    ];
+    let tweetContainer = document.getElementById('tweet-container');
+    tweets.forEach( function (tweetId) {
+        twttr.widgets.createTweet(tweetId, tweetContainer, {
+            cards: 'hidden',
+            width: '520',
+            align: 'center',
+        }).then( function (tweet) {
+                let style = tweet.shadowRoot.firstElementChild;
+                let css = document.createTextNode(`
+                    .EmbeddedTweet .CallToAction {display: none;}
+                    .SandboxRoot .EmbeddedTweet {
+                        box-shadow: 0 0 20px rgba(225, 232, 237, 0.8);
+                    } 
+                `);
+                style.appendChild(css);
+            });
+    });
+</script>
+

--- a/src/_includes/embedded-tweets.html
+++ b/src/_includes/embedded-tweets.html
@@ -8,14 +8,10 @@
         '1041026386377486336', //MalinaKirn
         '1057626199239868416', //bhoblin
         '1101265245056716800', //VTCodeCamp
-        '1053587150757945344', //VTCodeCamp
-        
         '1041030382228004865', //davekopec
-        '1045101432234487808', //VTCodeCamp
         '1041336710192418817', //FlorenceFong8
         '1041146235229560832', //tchen
-        '1042379420974178305', //VTCodeCamp
-        
+        '1042379420974178305', //VTCodeCamp     
     ];
     let tweetContainer = document.getElementById('tweet-container');
     tweets.forEach( function (tweetId) {

--- a/src/_includes/styles.css
+++ b/src/_includes/styles.css
@@ -37,9 +37,17 @@ h1, h2 {
     display: inline-block;
 }
 
+
 h2, h3 {
-    margin-top: 4rem;
+    margin-top: 2rem;
 }
+@media (min-width: 500px) {
+    h2, h3 {
+    margin-top: 3rem;
+}
+}
+
+
 
 .logo {
     max-width: 500px;
@@ -57,31 +65,47 @@ header.header {
     top: -115px;
 }
 
+/* Content sections layout */
 main {
     font-size: 1.1em;
     line-height: 1.5em;
     background: white;
 }
 main > section {
-    padding: 0 1rem;
+    padding: 0 1rem 1rem 1rem;
     margin: 0 auto;
+    width: 700px;
     max-width: 100%;
 }
+main > section.social {
+    width: 1000px;
+}
+section.past-years {
+    background: #f5f5f5;
+    padding-bottom: 3rem;
+}
+section.past-years > ul {
+    column-count: 3;
+    list-style: none;
+    padding: 0;
+    text-align: center;
+    max-width: 540px;
+    margin: 0 auto;
+}
+section.past-years > h2 {
+    margin-left: 10%;
+}
+
 @media (min-width: 500px) {
     main {
         padding: 1rem 0;
     }
     main > section {
-       padding: 0 2rem;
+       padding: 0 2rem 2rem 2rem;
     }
-}
-
-
-main > .main {
-    width: 700px;
-}
-main > .social {
-    width: 1000px;
+    section.past-years > ul {
+        padding: 0 15% 0 0;
+    }
 }
 
 
@@ -182,6 +206,9 @@ ul.nav-buttons a:focus {
         display: grid;
         grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
         grid-gap: 1rem 2rem;
+    }
+    main > section.past-years {
+        border-radius: 15px;
     }
 }
 

--- a/src/_includes/styles.css
+++ b/src/_includes/styles.css
@@ -41,10 +41,8 @@ h1, h2 {
 h2, h3 {
     margin-top: 2rem;
 }
-@media (min-width: 500px) {
-    h2, h3 {
-    margin-top: 3rem;
-}
+.section-content h1:first-child, .section-content h2:first-child {
+    margin-top: 0;
 }
 
 
@@ -72,19 +70,28 @@ main {
     background: white;
 }
 main > section {
-    padding: 0 1rem 1rem 1rem;
-    margin: 0 auto;
+    margin: 0;
+    width: 100%;
+    padding: 2rem 0;
+}
+section .section-content {
     width: 700px;
     max-width: 100%;
+    margin: 0 auto;
+    padding: 0 1rem;
 }
-main > section.social {
+section .section-content-wide {
     width: 1000px;
 }
+
 section.past-years {
     background: #f5f5f5;
+}
+section.past-years {
     padding-bottom: 3rem;
 }
-section.past-years > ul {
+
+section.past-years ul {
     column-count: 3;
     list-style: none;
     padding: 0;
@@ -92,19 +99,11 @@ section.past-years > ul {
     max-width: 540px;
     margin: 0 auto;
 }
-section.past-years > h2 {
-    margin-left: 10%;
-}
+
 
 @media (min-width: 500px) {
-    main {
-        padding: 1rem 0;
-    }
-    main > section {
-       padding: 0 2rem 2rem 2rem;
-    }
-    section.past-years > ul {
-        padding: 0 15% 0 0;
+    section .section-content {
+       padding: 0 2rem;
     }
 }
 
@@ -164,7 +163,7 @@ ul.nav-buttons a:focus {
 
 
 
-.content > .main > a {
+.content a {
     border-bottom: 3px solid hsl(198, 80%, 86%);
     box-shadow: inset 0 -4px 0 hsl(198, 80%, 86%);
     text-decoration: none;
@@ -194,21 +193,12 @@ ul.nav-buttons a:focus {
     background: hsl(198, 80%, 28%);
 }
 
-
-.embedded-tweets > .twitter-tweet {
-    width: 600px;
-    max-width: 100%;
-}
-
 @media (min-width: 700px) {
     .embedded-tweets {
         max-width: 100%;
         display: grid;
         grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
         grid-gap: 1rem 2rem;
-    }
-    main > section.past-years {
-        border-radius: 15px;
     }
 }
 

--- a/src/_includes/styles.css
+++ b/src/_includes/styles.css
@@ -32,7 +32,7 @@ header, main, footer {
     overflow-x: hidden;
 }
 
-h1 {
+h1, h2 {
     border-bottom: 4px solid #d7d700;
     display: inline-block;
 }
@@ -52,20 +52,38 @@ header.header {
     font-size: 1.2em;
     padding: 0.5em;
     border-bottom: 2px solid hsl(198, 64%, 13%);
-
+    z-index: 100;
     position: sticky;
     top: -115px;
 }
 
 main {
-    margin: 0 auto;
-    padding: 2rem;
-    padding-top: 1rem;
-    width: 700px;
     font-size: 1.1em;
     line-height: 1.5em;
     background: white;
 }
+main > section {
+    padding: 0 1rem;
+    margin: 0 auto;
+    max-width: 100%;
+}
+@media (min-width: 500px) {
+    main {
+        padding: 1rem 0;
+    }
+    main > section {
+       padding: 0 2rem;
+    }
+}
+
+
+main > .main {
+    width: 700px;
+}
+main > .social {
+    width: 1000px;
+}
+
 
 main img {
     max-width: 100%;
@@ -120,6 +138,8 @@ ul.nav-buttons a:focus {
     outline: none;
 }
 
+
+
 .content > .main > a {
     border-bottom: 3px solid hsl(198, 80%, 86%);
     box-shadow: inset 0 -4px 0 hsl(198, 80%, 86%);
@@ -131,14 +151,6 @@ ul.nav-buttons a:focus {
    color: black;
    background: hsl(198, 80%, 86%);
 }
-.twitter-timeline {
-    text-decoration: none;
-    margin-top: 15px;
-    display: inline-block;
-    color: hsl(198, 82%, 25%);
-    text-align: center;
-}
-
 .content a.cta {
     display: inline-block;
     box-shadow: none;
@@ -157,6 +169,23 @@ ul.nav-buttons a:focus {
 .content a.cta.active {
     background: hsl(198, 80%, 28%);
 }
+
+
+.embedded-tweets > .twitter-tweet {
+    width: 600px;
+    max-width: 100%;
+}
+
+@media (min-width: 700px) {
+    .embedded-tweets {
+        max-width: 100%;
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+        grid-gap: 1rem 2rem;
+    }
+}
+
+
 
 
 footer a svg {
@@ -180,38 +209,6 @@ footer a svg {
     display: inline-block;
     margin: 0px 15px;
 }
-
-
-.content {
-    display: flex;
-    
-}
-.twitter {
-    width: 160px;
-}
-.twitter iframe {
-    height: 100% !important;
-}
-
-
-
-@media (max-width: 800px) {
-    .content {
-        flex-direction: column;
-        
-    }
-    .twitter {
-        width: 100%;
-        max-height: 500px
-    }
-    .twitter iframe {
-        width: 100%;
-        max-height: 500px !important;
-    }
-}
-
-
-
 
 .copy-line {
     display: flex;
@@ -242,10 +239,6 @@ footer a svg {
 }
 
 @media (max-width: 500px) {
-    header.header {
-        top: 0;
-        position: relative;
-    }
     ul.nav-buttons a {
         margin: 0px 3px;
     }

--- a/src/conduct.md
+++ b/src/conduct.md
@@ -4,6 +4,7 @@ title:  "Code of Conduct"
 ---
 
 <section class="main" >
+<div class="section-content">
 
 # {{title}}
 
@@ -91,4 +92,5 @@ This Code of Conduct is distributed under a [Creative Commons Attribution-ShareA
 
 Based on the [UX Burlington](http://uxburlington.com/) [Code of Conduct](http://uxburlington.com/conduct/), which was adapted from the [Citizen Code of Conduct](http://citizencodeofconduct.org/), [Pycon Attendee Procedure for incident handling](https://github.com/python/pycon-code-of-conduct/blob/master/Attendee%20Procedure%20for%20incident%20handling.md) and [Pycon Staff Procedure for incident handling](https://github.com/python/pycon-code-of-conduct/blob/master/Staff%20Procedure%20for%20incident%20handling.md) on 16 February 2014.
 
+</div>
 </section>

--- a/src/conduct.md
+++ b/src/conduct.md
@@ -3,6 +3,9 @@ layout: default-layout.njk
 title:  "Code of Conduct"
 ---
 
+<section class="main" >
+
+# {{title}}
 
 ## 1. Purpose
 
@@ -87,3 +90,5 @@ Email: [team@vtcodecamp.org](mailto:team@vtcodecamp.org) (this email address may
 This Code of Conduct is distributed under a [Creative Commons Attribution-ShareAlike license](http://creativecommons.org/licenses/by-sa/3.0/).
 
 Based on the [UX Burlington](http://uxburlington.com/) [Code of Conduct](http://uxburlington.com/conduct/), which was adapted from the [Citizen Code of Conduct](http://citizencodeofconduct.org/), [Pycon Attendee Procedure for incident handling](https://github.com/python/pycon-code-of-conduct/blob/master/Attendee%20Procedure%20for%20incident%20handling.md) and [Pycon Staff Procedure for incident handling](https://github.com/python/pycon-code-of-conduct/blob/master/Staff%20Procedure%20for%20incident%20handling.md) on 16 February 2014.
+
+</section>

--- a/src/diversity.md
+++ b/src/diversity.md
@@ -3,6 +3,10 @@ layout: default-layout.njk
 title:  "Diversity Statement"
 ---
 
+<section class="main" >
+
+# {{title}}
+
 Our goal is to create an inclusive, respectful event environment that invites participation from people of all races, ethnicities, gender identities or expressions, ages, abilities, religions (or lack thereof), sexual orientations, and educational levels.
 
 We're actively seeking to increase the diversity of our attendees, speakers, and sponsors through our calls for proposals, other open submission processes, and through dialogue with the larger communities we serve.
@@ -21,3 +25,5 @@ Here are some ways you can help us build a more diverse conference experience:
 We value diversity in the communities we bring together, and we welcome your contributions to bringing balanced representation of the richness of our collective human experience.
 
 The above Conference Diversity statement is licensed by O'Reilly Media, Inc. under the Creative Commons Attribution 3.0 United States License: [Creative Commons 3.0](http://creativecommons.org/licenses/by/3.0/us/). Based on the [UX Burlington](http://uxburlington.com/) [Diversity Statement](http://uxburlington.com/diversity/).
+
+</section>

--- a/src/diversity.md
+++ b/src/diversity.md
@@ -4,6 +4,7 @@ title:  "Diversity Statement"
 ---
 
 <section class="main" >
+<div class="section-content">
 
 # {{title}}
 
@@ -26,4 +27,5 @@ We value diversity in the communities we bring together, and we welcome your con
 
 The above Conference Diversity statement is licensed by O'Reilly Media, Inc. under the Creative Commons Attribution 3.0 United States License: [Creative Commons 3.0](http://creativecommons.org/licenses/by/3.0/us/). Based on the [UX Burlington](http://uxburlington.com/) [Diversity Statement](http://uxburlington.com/diversity/).
 
+</div>
 </section>

--- a/src/index.md
+++ b/src/index.md
@@ -1,6 +1,7 @@
 ---
 layout: default-layout.njk
 title:  "About the Event"
+homepage: true
 ---
 
 <section class="main">
@@ -22,6 +23,23 @@ The upcoming 11th annual Vermont Code Camp will be held on Saturday, September 2
 The entire day is **free**, including morning coffee & pastries, lunch and afternoon snacks for all attendees. The event will bring together technology community members, students and professionals from around Vermont and beyond. A wide variety of software technologies will be represented. Session topics range from software development (e.g. languages, tools, practices, databases, web development, etc.) to the business of software and technology (e.g. entrepreneurship, consulting, team dynamics, etc.).
 
 </section>
+
+<section class="past-years">
+
+## Past Years
+
+* [2018](https://www.vtcodecamp.org)
+* [2017](https://www.vtcodecamp.org/2017)
+* [2016](https://www.vtcodecamp.org/2016)
+* [2015](https://www.vtcodecamp.org/2015)
+* [2014](https://www.vtcodecamp.org/2014)
+* [2013](https://www.vtcodecamp.org/2013)
+* [2012](https://www.vtcodecamp.org/2012)
+* [2011](https://www.vtcodecamp.org/2011)
+* [2010](https://www.vtcodecamp.org/2010)
+
+</section>
+
 
 <section class="social">
 

--- a/src/index.md
+++ b/src/index.md
@@ -5,6 +5,7 @@ homepage: true
 ---
 
 <section class="main">
+<div class="section-content">
 
 # {{title}}
 
@@ -22,9 +23,12 @@ The upcoming 11th annual Vermont Code Camp will be held on Saturday, September 2
 
 The entire day is **free**, including morning coffee & pastries, lunch and afternoon snacks for all attendees. The event will bring together technology community members, students and professionals from around Vermont and beyond. A wide variety of software technologies will be represented. Session topics range from software development (e.g. languages, tools, practices, databases, web development, etc.) to the business of software and technology (e.g. entrepreneurship, consulting, team dynamics, etc.).
 
+</div>
 </section>
 
 <section class="past-years">
+<div class="section-content">
+
 
 ## Past Years
 
@@ -38,10 +42,13 @@ The entire day is **free**, including morning coffee & pastries, lunch and after
 * [2011](https://www.vtcodecamp.org/2011)
 * [2010](https://www.vtcodecamp.org/2010)
 
+
+</div>
 </section>
 
 
 <section class="social">
+<div class="section-content">
 
 ## Social
 
@@ -49,6 +56,10 @@ Follow [@VTCodeCamp](https://twitter.com/VTCodeCamp) for event updates.
 
 Use the hashtag [#VTCC11](https://twitter.com/search?q=%23VTCC10) when posting about the event.
 
+</div>
+<div class="section-content section-content-wide">
+
 {% include embedded-tweets.html %}
 
+</div>
 </section>

--- a/src/index.md
+++ b/src/index.md
@@ -1,8 +1,11 @@
 ---
 layout: default-layout.njk
 title:  "About the Event"
-permalink: "index.html"
 ---
+
+<section class="main">
+
+# {{title}}
 
 <div class="text-large">
     On Saturday, September 28, 2019 <br/>
@@ -17,3 +20,17 @@ The upcoming 11th annual Vermont Code Camp will be held on Saturday, September 2
 
 
 The entire day is **free**, including morning coffee & pastries, lunch and afternoon snacks for all attendees. The event will bring together technology community members, students and professionals from around Vermont and beyond. A wide variety of software technologies will be represented. Session topics range from software development (e.g. languages, tools, practices, databases, web development, etc.) to the business of software and technology (e.g. entrepreneurship, consulting, team dynamics, etc.).
+
+</section>
+
+<section class="social">
+
+## Social
+
+Follow [@VTCodeCamp](https://twitter.com/VTCodeCamp) for event updates.
+
+Use the hashtag [#VTCC11](https://twitter.com/search?q=%23VTCC10) when posting about the event.
+
+{% include embedded-tweets.html %}
+
+</section>

--- a/src/parking.md
+++ b/src/parking.md
@@ -4,6 +4,7 @@ title:  "Champlain College Parking Information"
 ---
 
 <section class="main" >
+<div class="section-content">
 
 # {{title}}
 
@@ -17,4 +18,5 @@ The Vermont Code Camp registration and welcome will take place in the Champlain 
 
 ![Champlain College Campus Map](/assets/cc_parking_map_20180719.png)
 
+</div>
 </section>

--- a/src/parking.md
+++ b/src/parking.md
@@ -3,6 +3,10 @@ layout: default-layout.njk
 title:  "Champlain College Parking Information"
 ---
 
+<section class="main" >
+
+# {{title}}
+
 Vermont Code Camp is located in the Center for Communication & Creative Media (CCM), building 13 on the map below. Along with street parking, Vermont Code Camp parking is available on campus in Champlain College lots. Participants are welcome to park without a permit and free of charge in lots marked #3, #4, and $ (metered) on the attached parking map. We ask that you refrain from parking in the Admissions lot off Maple Street, marked on the map with an exclamation point (restricted).
 
 We anticipate parking will be tight, so we encourage you to [walk](http://www.champlain.edu/current-students/campus-services/transportation-and-parking/walk), [bike](http://www.champlain.edu/current-students/campus-services/transportation-and-parking/bike), [bus](http://www.champlain.edu/current-students/campus-services/transportation-and-parking/bus), or carpool.
@@ -12,3 +16,5 @@ For speakers or sponsors who may need to load or unload equipment, you are welco
 The Vermont Code Camp registration and welcome will take place in the Champlain Room located on the 3rd floor of the CCM Building.
 
 ![Champlain College Campus Map](/assets/cc_parking_map_20180719.png)
+
+</section>

--- a/src/speak.md
+++ b/src/speak.md
@@ -5,6 +5,7 @@ title:  "Speak at VT Code Camp 2019"
 
 
 <section class="main" >
+<div class="section-content">   
 
 # {{title}}
 
@@ -29,4 +30,5 @@ Possible topics include .NET, PHP, Ruby, Python, Java&hellip;really, anything re
 
 Sessions are typically 30 minutes to 1 hour in duration, including time for questions. Feel free to submit one or several session proposals.
 
+</div>
 </section>

--- a/src/speak.md
+++ b/src/speak.md
@@ -4,6 +4,10 @@ title:  "Speak at VT Code Camp 2019"
 ---
 
 
+<section class="main" >
+
+# {{title}}
+
 <div class="landing-image">
     <svg xmlns="http://www.w3.org/2000/svg"  
          xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -25,3 +29,4 @@ Possible topics include .NET, PHP, Ruby, Python, Java&hellip;really, anything re
 
 Sessions are typically 30 minutes to 1 hour in duration, including time for questions. Feel free to submit one or several session proposals.
 
+</section>

--- a/src/sponsor.md
+++ b/src/sponsor.md
@@ -3,6 +3,10 @@ layout: default-layout.njk
 title:  "Sponsor VT Code Camp 2019"
 ---
 
+<section class="main" >
+
+# {{title}}
+
 <div class="landing-image">
     <svg xmlns="http://www.w3.org/2000/svg"  
          xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -27,3 +31,5 @@ While we keep our budget trim, we can’t pull off VT Code Camp without the fina
 * **Simplify our lives**: send your great software to raffle
 * **Promote us**: give us advertising space
 * **Entertain us**: sponsor the after party for speakers and volunteers
+
+</section>

--- a/src/sponsor.md
+++ b/src/sponsor.md
@@ -4,6 +4,7 @@ title:  "Sponsor VT Code Camp 2019"
 ---
 
 <section class="main" >
+<div class="section-content">
 
 # {{title}}
 
@@ -32,4 +33,5 @@ While we keep our budget trim, we can’t pull off VT Code Camp without the fina
 * **Promote us**: give us advertising space
 * **Entertain us**: sponsor the after party for speakers and volunteers
 
+</div>
 </section>

--- a/src/sponsorinfo.md
+++ b/src/sponsorinfo.md
@@ -3,6 +3,9 @@ layout: default-layout.njk
 title:  "Sponsor Info"
 ---
 
+<section class="main">
+<div class="section-content">
+
 ![VTCC Logo](https://github.com/vtcodecamp/documents/blob/master/logos/vermont-code-camp-logo-dark.svg)
 
 # Vermont Code Camp 2018<br/>Sponsor Information  
@@ -47,3 +50,7 @@ With respect to swag, we can arrange someone to relay it the week of the event o
 Thank you for your interest and support.
 
  Rob Hale and Julie Lerman on behalf of the Vermont Code Camp team
+
+<div>
+</section>
+


### PR DESCRIPTION
I removed the getHistory nav item from the top bar and instead put a "Past Years" section on the home page.  It didn't feel quite right to me to have history in the to navigation since it takes the user away from this years site.  It also didn't feel right having no Home (or Attend) nav item and removing history makes room for that.  I also feel like linking to each year explicitly visually shows how long they've been doing this code camp.  Your thoughts? 

I replaced the site wide twitter side bar with a social section on the home page.  I think it's more relevant on just the home page since that page is all about promoting the event, and it lets the other pages be more focused.  What do you think?

I was originally looking to include that same timeline of the latest tweets from vtcodecamp, and a timeline of the latest tweets with the hashtag #VTCC10 (to be changed to #VTCC11 once that starts getting used).  However, twitter doesn't seem to offer a timeline widget for hashtags.  So I figured we could just embed specific tweets to start.  Once I got going with embedding specific tweets though, I got to thinking it might be a better way to go anyway.  If people want to see *all* vtcodecamp tweets, or *all* #VTCC10 tweets, the best place is twitter.com, not vtcodecamp.com. What vtcodecamp.com can do better is curate a selection of the best tweets that paint a picture of our event, so that's what I've done for now.  I think it's a pretty nice effect.  Let me know your thoughts. 


