### PR TITLE
Add Table of Contents (ToC) to Code of Conduct (CoC)

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,4 +1,4 @@
-const CleanCSS = require("clean-css");
+
 
 module.exports = function(eleventyConfig) {
 
@@ -7,6 +7,7 @@ module.exports = function(eleventyConfig) {
     eleventyConfig.addPassthroughCopy("src/favicon.ico");
 
     // add cssmin filter
+    const CleanCSS = require("clean-css");
     eleventyConfig.addFilter("cssmin", function(code) {
         return new CleanCSS({}).minify(code).styles;
     });
@@ -15,6 +16,7 @@ module.exports = function(eleventyConfig) {
         return value.replace('/src','');
     });
 
+    // set markdown defaults (inline so we can extend)
     let markdownIt = require("markdown-it");
     let options = {
       html: true,
@@ -22,12 +24,10 @@ module.exports = function(eleventyConfig) {
       linkify: true
     };
     
-    eleventyConfig.setLibrary("md", markdownIt(options));
-
-    /* Markdown */
+    // add markdown anchor options
 	let markdownItAnchor = require("markdown-it-anchor");
 	let opts = {
-		permalink: true,
+		permalink: false,
 		slugify: function(s) {
             // strip special chars
             let newStr = s.replace(/[^a-z ]/gi,'').trim();
@@ -42,6 +42,10 @@ module.exports = function(eleventyConfig) {
 
     eleventyConfig.setLibrary("md", markdownIt(options).use(markdownItAnchor, opts));
     
+    // add table of contents plugin
+    const pluginTOC = require('eleventy-plugin-nesting-toc');
+    eleventyConfig.addPlugin(pluginTOC);
+
     return {
         dir: {
             input: "src",

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,6 +1,5 @@
 const CleanCSS = require("clean-css");
 
-
 module.exports = function(eleventyConfig) {
 
     // Copy the `assets/` directory (css, images, etc)
@@ -16,6 +15,33 @@ module.exports = function(eleventyConfig) {
         return value.replace('/src','');
     });
 
+    let markdownIt = require("markdown-it");
+    let options = {
+      html: true,
+      breaks: true,
+      linkify: true
+    };
+    
+    eleventyConfig.setLibrary("md", markdownIt(options));
+
+    /* Markdown */
+	let markdownItAnchor = require("markdown-it-anchor");
+	let opts = {
+		permalink: true,
+		slugify: function(s) {
+            // strip special chars
+            let newStr = s.replace(/[^a-z ]/gi,'').trim();
+            // take first 4 words and separate with "-""
+            newStr = newStr.split(" ").slice(0,4).join("-");
+			return newStr;
+		},
+		permalinkClass: "direct-link",
+		permalinkSymbol: "#",
+		level: [1,2,3,4]
+	};
+
+    eleventyConfig.setLibrary("md", markdownIt(options).use(markdownItAnchor, opts));
+    
     return {
         dir: {
             input: "src",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
             "type": "node",
             "request": "launch",
             "name": "Launch 11ty",
-            "program": "${workspaceFolder}\\node_modules\\@11ty\\eleventy\\cmd.js",
+            "program": "${workspaceFolder}/node_modules/@11ty/eleventy/cmd.js",
             "args": [],
         },
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3173,6 +3173,11 @@
         "uc.micro": "^1.0.5"
       }
     },
+    "markdown-it-anchor": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-5.2.4.tgz",
+      "integrity": "sha512-n8zCGjxA3T+Mx1pG8HEgbJbkB8JFUuRkeTZQuIM8iPY6oQ8sWOPRZJDFC9a/pNg2QkHEjjGkhBEl/RSyzaDZ3A=="
+    },
     "maximatch": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/maximatch/-/maximatch-0.1.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,6 +81,11 @@
         "@types/babel-types": "*"
       }
     },
+    "@types/node": {
+      "version": "12.6.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.8.tgz",
+      "integrity": "sha512-aX+gFgA5GHcDi89KG5keey2zf0WfZk/HAQotEamsK2kbey+8yGKcson0hbK8E+v0NArlCJQCqMP161YhV6ZXLg=="
+    },
     "a-sync-waterfall": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
@@ -480,6 +485,11 @@
       "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig==",
       "dev": true
     },
+    "boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -697,6 +707,19 @@
       "dev": true,
       "requires": {
         "is-regex": "^1.0.3"
+      }
+    },
+    "cheerio": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz",
+      "integrity": "sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==",
+      "requires": {
+        "css-select": "~1.2.0",
+        "dom-serializer": "~0.1.1",
+        "entities": "~1.1.1",
+        "htmlparser2": "^3.9.1",
+        "lodash": "^4.15.0",
+        "parse5": "^3.0.1"
       }
     },
     "chokidar": {
@@ -935,6 +958,22 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "css-select": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+      "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+      "requires": {
+        "boolbase": "~1.0.0",
+        "css-what": "2.1",
+        "domutils": "1.5.1",
+        "nth-check": "~1.0.1"
+      }
+    },
+    "css-what": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
+      "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg=="
+    },
     "date-time": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/date-time/-/date-time-0.1.1.tgz",
@@ -1167,6 +1206,37 @@
       "integrity": "sha1-6oCxBqh1OHdOijpKWv4pPeSJ4Kk=",
       "dev": true
     },
+    "dom-serializer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
+      "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
+      "requires": {
+        "domelementtype": "^1.3.0",
+        "entities": "^1.1.1"
+      }
+    },
+    "domelementtype": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
+    },
+    "domhandler": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+      "requires": {
+        "domelementtype": "1"
+      }
+    },
+    "domutils": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+      "requires": {
+        "dom-serializer": "0",
+        "domelementtype": "1"
+      }
+    },
     "easy-extender": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/easy-extender/-/easy-extender-2.3.4.tgz",
@@ -1216,6 +1286,14 @@
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.1.tgz",
       "integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ==",
       "dev": true
+    },
+    "eleventy-plugin-nesting-toc": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eleventy-plugin-nesting-toc/-/eleventy-plugin-nesting-toc-1.1.0.tgz",
+      "integrity": "sha512-E/rL7YpqcWLGJR87HzL/lccFdkK0iRWpwJhUKmsRnCOtqUuiY/2MZdD7g49eh2v13whYfmzdUiIgd/Zz1oWM9w==",
+      "requires": {
+        "cheerio": "^1.0.0-rc.3"
+      }
     },
     "emitter-mixin": {
       "version": "0.0.3",
@@ -1322,8 +1400,7 @@
     "entities": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
-      "dev": true
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
     },
     "errno": {
       "version": "0.1.7",
@@ -2536,6 +2613,31 @@
       "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
       "dev": true
     },
+    "htmlparser2": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+      "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+      "requires": {
+        "domelementtype": "^1.3.1",
+        "domhandler": "^2.3.0",
+        "domutils": "^1.5.1",
+        "entities": "^1.1.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^3.1.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
     "http-errors": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
@@ -2613,8 +2715,7 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
       "version": "1.3.5",
@@ -3084,8 +3185,7 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-      "dev": true
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.isfinite": {
       "version": "3.3.2",
@@ -3458,6 +3558,14 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
     },
+    "nth-check": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
+      "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+      "requires": {
+        "boolbase": "~1.0.0"
+      }
+    },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
@@ -3699,6 +3807,14 @@
       "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-0.1.2.tgz",
       "integrity": "sha1-3T+iXtbC78e93hKtm0bBY6opIk4=",
       "dev": true
+    },
+    "parse5": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
+      "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "parseqs": {
       "version": "0.0.5",
@@ -4418,8 +4534,7 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -5044,7 +5159,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -5433,8 +5547,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utils-merge": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "VT Code Camp 2019 website",
   "main": "index.js",
   "dependencies": {
-    "clean-css": "^4.2.1"
+    "clean-css": "^4.2.1",
+    "markdown-it-anchor": "^5.2.4"
   },
   "devDependencies": {
     "@11ty/eleventy": "^0.8.2"

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "clean-css": "^4.2.1",
+    "eleventy-plugin-nesting-toc": "^1.1.0",
     "markdown-it-anchor": "^5.2.4"
   },
   "devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -63,6 +63,7 @@ npm run serve   # builds site + serves `_site` dirrectory
 * [11ty - 404 page](https://www.11ty.io/docs/quicktips/not-found/)
 * [11ty - environment variables](https://www.11ty.io/docs/data-js/#example%3A-exposing-environment-variables)
 * [11ty - filters](https://www.11ty.io/docs/filters/)
+* [11ty - plugins](https://www.11ty.io/docs/plugins/)
 * [netlify - environment variables](https://www.netlify.com/docs/continuous-deployment/#environment-variables)
 * [netlify - TOML](https://www.netlify.com/docs/netlify-toml-reference/)
 * [netlify - Build](https://www.netlify.com/products/build/)
@@ -88,3 +89,5 @@ npm run serve   # builds site + serves `_site` dirrectory
 * [twitter - style tweets](https://medium.com/@makerspirit/how-to-style-your-twitter-widget-styling-on-shadow-dom-a405c36edd10)
 * [json schema - url format](https://github.com/json-schema-org/json-schema-spec/issues/233#issuecomment-279180514)
 * [json schema - array of type](https://stackoverflow.com/a/51557536/1366033)
+* [npm - markdown-it-anchor](https://www.npmjs.com/package/markdown-it-anchor)
+* [md - extended syntax - ids](https://www.markdownguide.org/extended-syntax/#heading-ids)

--- a/readme.md
+++ b/readme.md
@@ -69,6 +69,7 @@ npm run serve   # builds site + serves `_site` dirrectory
 * [netlify - Dev](https://www.netlify.com/products/dev/)
 * [netlify - Deploy Previews](https://www.netlify.com/docs/webhooks/#github-commit-statuses)
 * [vs code - Workspace recommended extensions](https://code.visualstudio.com/docs/editor/extension-gallery#_workspace-recommended-extensions)
+* [vs code - debug on windows and mac](https://stackoverflow.com/a/42471528/1366033)
 * [nunjucks - operators & logic](https://mozilla.github.io/nunjucks/templating.html#comparisons)
 * [nunjucks - check if variable in string](https://github.com/mozilla/nunjucks/issues/676)
 * [nunjucks - inline if expression](https://mozilla.github.io/nunjucks/templating.html#if-expression)

--- a/src/_includes/styles.css
+++ b/src/_includes/styles.css
@@ -454,3 +454,30 @@ a.friend-link:hover {
 .sponsor-logo-list .scale-120 img { transform: scale(1.2); }
 .sponsor-logo-list .scale-130 img { transform: scale(1.3); }
 .sponsor-logo-list .scale-140 img { transform: scale(1.4); }
+
+/* make sure fragment urls fit under fixed header */
+[id] {
+    margin-top: -80px;
+    padding-top: 80px;
+    position: relative;
+}
+
+/* allows links to be ontop of negative padding in h2 elements */
+.content a {
+    position: relative;
+    z-index: 1;
+}
+
+.content .direct-link {
+    position: absolute;
+    left: -34px;
+    bottom: -2px;
+    display: none;
+    padding: 10px;
+    padding-bottom: 0;
+}
+
+h2:hover .direct-link,
+h2 .direct-link:hover {
+    display: block;
+}

--- a/src/_includes/styles.css
+++ b/src/_includes/styles.css
@@ -233,14 +233,14 @@ ul.nav-buttons a {
     background: hsl(198, 80%, 36%);
 }
 ul.nav-buttons a:hover {
-    background: hsl(198, 80%, 33%);
+    background: hsl(198, 80%, 31%);
 }
 ul.nav-buttons a.active {
-    background: hsl(198, 80%, 28%);
+    background: hsl(198, 80%, 27%);
 }
 ul.nav-buttons a:focus {
     border-color: hsl(198, 100%, 60%);
-    background: hsl(198, 80%, 28%);
+    background: hsl(198, 80%, 27%);
     outline: none;
 }
 
@@ -260,9 +260,14 @@ ul.nav-buttons a:focus {
     transition: background .25s ease;
     color: black
 }
-.content a:hover {
+.content a:hover,
+.content a:focus {
    color: black;
    background: hsl(198, 80%, 86%);
+}
+.content a:focus {
+    outline: 2px solid hsla(198, 78%, 65%, 1);
+    box-shadow: 0px 0px 2px 2px hsla(198, 78%, 65%);
 }
 .content a.cta {
     display: inline-block;

--- a/src/_includes/styles.css
+++ b/src/_includes/styles.css
@@ -464,7 +464,10 @@ a.friend-link:hover {
 .sponsor-logo-list .scale-140 img { transform: scale(1.4); }
 
 /* make sure fragment urls fit under fixed header */
-[id] {
+h1[id],
+h2[id],
+h3[id],
+h4[id] {
     margin-top: -80px;
     padding-top: 80px;
     position: relative;

--- a/src/_includes/styles.css
+++ b/src/_includes/styles.css
@@ -79,7 +79,9 @@ h1::after, h2::after {
     display: block;
     margin-bottom: 1.5em;
 }
-
+h2::after {
+    margin-bottom: 1em;
+}
 
 h2, h3 {
     margin-top: 2rem;
@@ -162,7 +164,8 @@ section.past-years ul {
     margin: 0 auto;
 }
 
-section.sponsors {
+section.sponsors,
+section.section-toc + section.main {
     background: linear-gradient(#f5f5f5 0, #fff 150px, #fff 100%)
 }
 
@@ -485,4 +488,25 @@ a.friend-link:hover {
 h2:hover .direct-link,
 h2 .direct-link:hover {
     display: block;
+}
+
+.toc ol {
+    padding-left: 0px;
+    list-style: none;
+}
+
+.toc li::before {
+  content: "#";
+  margin-left: -10px;
+  padding-right: 4px;
+  visibility: hidden;
+}
+
+.toc li:hover::before {
+  visibility: visible
+}
+
+.toc li a {
+    border: none;
+    box-shadow: none;
 }

--- a/src/_includes/styles.css
+++ b/src/_includes/styles.css
@@ -509,7 +509,9 @@ h2 .direct-link:hover {
   visibility: visible
 }
 
+.toc li {
+    margin-bottom: 0.5rem;
+}
 .toc li a {
     border: none;
-    box-shadow: none;
 }

--- a/src/_includes/toc-layout.njk
+++ b/src/_includes/toc-layout.njk
@@ -1,0 +1,21 @@
+---
+layout: default-layout.njk
+---
+
+<section class="section-toc" >
+<div class="section-content">
+
+    <h1>{{title}}</h1>
+
+    <aside class="content">
+
+        {{ content | toc | safe }}
+
+    </aside>
+
+</div>
+</section>
+
+
+
+{{ content | safe }}

--- a/src/conduct.md
+++ b/src/conduct.md
@@ -1,5 +1,5 @@
 ---
-layout: default-layout.njk
+layout: toc-layout.njk
 title:  "Code of Conduct"
 meta_description: This code of conduct outlines our expectations for all those who participate in our event, as well as the consequences for unacceptable behavior.
 ---
@@ -7,7 +7,6 @@ meta_description: This code of conduct outlines our expectations for all those w
 <section class="main" >
 <div class="section-content">
 
-# {{title}}
 
 ## 1. Purpose
 
@@ -120,7 +119,7 @@ We expect all community participants (contributors, paid or otherwise; sponsors;
 
 Email: [team@vtcodecamp.org](mailto:team@vtcodecamp.org) (this email address may not be monitored during in-person events)
 
-## 10. License and Attribution
+## 11. License and Attribution
 
 This Code of Conduct is distributed under a [Creative Commons Attribution-ShareAlike license](http://creativecommons.org/licenses/by-sa/3.0/).
 

--- a/src/index.njk
+++ b/src/index.njk
@@ -47,7 +47,10 @@ meta_description: Vermont Code Camp is a full day event that brings together tec
 <section class="sponsors">
     
     <div class="section-content">
-        <h2>Sponsors</h2>
+        <h2 id="Sponsors">
+            Sponsors
+            <a class="direct-link" href="#Sponsors" aria-hidden="true">#</a>
+        </h2>
     </div>
 
     {% include "sponsor-logos.njk" %}
@@ -57,7 +60,10 @@ meta_description: Vermont Code Camp is a full day event that brings together tec
 <section class="past-years">
     <div class="section-content">
 
-    <h2>Past Years</h2>
+    <h2 id="Past-Years">
+        Past Years
+        <a class="direct-link" href="#Past-Years" aria-hidden="true">#</a>
+    </h2>
     <ul>
         <li><a href="https://archive.vtcodecamp.org">2018</a></li>
         <li><a href="https://archive.vtcodecamp.org/2017">2017</a></li>
@@ -77,7 +83,10 @@ meta_description: Vermont Code Camp is a full day event that brings together tec
 <section class="social">
     <div class="section-content">
 
-        <h2>Social</h2>
+        <h2 id="Social">
+            Social
+            <a class="direct-link" href="#Social" aria-hidden="true">#</a>
+        </h2>
         <p>Follow <a href="https://twitter.com/VTCodeCamp">@VTCodeCamp</a> for event updates.</p>
         <p>Use the hashtag <a href="https://twitter.com/hashtag/VTCC11">#VTCC11</a> when posting about the event.</p>
 


### PR DESCRIPTION
We can merge against other changes to the CoC, but this should help navigate to particular sections of of the code of conduct since it's pretty long.  

Also gives each header element a unique id - so we can build fragment urls and link directly to them.

<img src="https://user-images.githubusercontent.com/4307307/62018963-dfcf0380-b18a-11e9-9036-8ccf19ae9410.png" width="500px" />
